### PR TITLE
Do not add type (06) for state blocks

### DIFF
--- a/msg_publish.py
+++ b/msg_publish.py
@@ -30,7 +30,7 @@ class msg_publish:
 
     def serialise(self):
         data = self.hdr.serialise_header()
-        data += self.block.serialise(True)
+        data += self.block.serialise(False)
         return data
 
     @classmethod


### PR DESCRIPTION
According to https://docs.nano.org/protocol-design/blocks/#state-blocks the type is not needed for state blocks.
Publishing works fine, when we do not add the leading '06' to the block.