### PR TITLE
Fix TypeError while joining aliases

### DIFF
--- a/peercrawler_html_server.py
+++ b/peercrawler_html_server.py
@@ -46,8 +46,8 @@ def main_website():
 
             peer_list.append([peer.ip,
                               peer.port,
-                              " // ".join(aliases),
-                              " // ".join(accounts),
+                              " // ".join(filter(lambda n: isinstance(n, str), aliases)),  # filter out None values
+                              " // ".join(filter(lambda n: isinstance(n, str), accounts)),
                               peer.is_voting,
                               telemetry.sig_verified,
                               node_id,


### PR DESCRIPTION
Fixes #13.
This happens because the alias of some of the PRs fetched from nano.community is None. Filtering out non-string values should fix this.