### PR TITLE
Move network_connections graph to peer_manager

### DIFF
--- a/peercrawler.py
+++ b/peercrawler.py
@@ -11,7 +11,7 @@ from _thread import interrupt_main
 from ipaddress import IPv6Address
 import jsonpickle
 from functools import reduce
-from typing import Iterable, Optional
+from typing import Collection, Iterable, Optional
 from concurrent.futures import ThreadPoolExecutor
 
 from pydot import Dot, Node, Edge
@@ -43,11 +43,12 @@ class peer_manager:
         self.ctx = ctx
         self.verbosity = verbosity
         self.mutex = threading.Lock()
-        self.peers = peer_set()
         self.listening_port = listening_port
 
-        if peers:
-            self.add_peers(peers)
+        self.__connections_graph: dict[Peer, peer_set] = {}
+
+        for peer in peers:
+            self.__connections_graph[peer] = peer_set()
 
         if listen:
             threading.Thread(target=self.listen_incoming, daemon=True).start()
@@ -56,21 +57,32 @@ class peer_manager:
             thread = threading.Thread(target=self.run_periodic_cleanup, args=(inactivity_threshold_seconds,), daemon=True)
             thread.start()
 
-    def add_peers(self, new_peers: Iterable[Peer]):
+    def add_peers(self, from_peer: Peer, new_peers: Iterable[Peer]):
         with self.mutex:
-            new_peers = filter(lambda p: not p.ip.ipv6.is_unspecified, new_peers)  # filter out unspecified addresses
-            self.peers.update(new_peers)
+            for new_peer in new_peers:
+                if new_peer.ip.ipv6.is_unspecified:
+                    continue
+
+                if new_peer not in self.__connections_graph:
+                    self.__connections_graph[new_peer] = peer_set()
+
+                self.__connections_graph[from_peer].add(new_peer)
 
     def run_periodic_cleanup(self, inactivity_threshold_seconds):
         while True:
             with self.mutex:
-                self.peers.cleanup_inactive(inactivity_threshold_seconds)
+                for peer_collection in self.__connections_graph.values():
+                    peer_collection.cleanup_inactive(inactivity_threshold_seconds)
 
             time.sleep(inactivity_threshold_seconds)
 
-    def get_peers_copy(self):
+    def get_peers_copy(self) -> Collection[Peer]:
         with self.mutex:
-            return copy.copy(self.peers)
+            return self.__connections_graph.keys()
+
+    def get_connections_graph(self) -> dict[Peer, set[Peer]]:
+        with self.mutex:
+            return copy.deepcopy(self.__connections_graph)
 
     def count_good_peers(self):
         counter = 0
@@ -104,8 +116,7 @@ class peer_manager:
         try:
             result = self.handle_incoming(connection, address, self.ctx)
             if result:
-                result[1].append(result[0])
-                self.add_peers(result[1])
+                self.add_peers(result[0], result[1])
         finally:
             semaphore.release()
             connection.close()
@@ -217,7 +228,7 @@ class peer_manager:
             logger.debug("Query %41s:%5s (score:%4s)" % ('[%s]' % p.ip, p.port, p.score))
 
             new_peers = self.get_peers_from_peer(peer)
-            self.add_peers(new_peers)
+            self.add_peers(peer, new_peers)
 
         with ThreadPoolExecutor(max_workers=max_workers) as t:
             for p in peers_copy:
@@ -225,7 +236,9 @@ class peer_manager:
 
     def crawl(self, forever, delay, max_workers=4):
         initial_peers = get_all_dns_addresses_as_peers(self.ctx['peeraddr'], self.ctx['peerport'], -1)
-        self.add_peers(initial_peers)
+        with self.mutex:
+            for peer in initial_peers:
+                self.__connections_graph[peer] = peer_set()
 
         self.crawl_once(max_workers)
         logger.info(self)
@@ -240,21 +253,23 @@ class peer_manager:
             count += 1
 
     def __str__(self):
-        with self.mutex:
-            good = reduce(lambda c, p: c + int(p.score >= 1000), self.peers, 0)
-            s = '---------- Start of Manager peers (%s peers, %s good) ----------\n' % (len(self.peers), good)
-            for p in self.peers:
-                voting_str = ' (voting)' if p.is_voting else ''
-                sw_ver = ''
-                cemented_count = ''
-                if p.telemetry:
-                    sw_ver = ' v' + p.telemetry.get_sw_version()
-                    cemented_count = ' cc=%s' % p.telemetry.cemented_count
-                s += '%41s:%5s (score:%4s)%s%s%s\n' % \
-                     ('[%s]' % p.ip, p.port, p.score, sw_ver, cemented_count, voting_str)
-                # if p.score >= 1000:
-                #    s += 'ID: %s, voting:%s\n' % (acctools.to_account_addr(p.peer_id, prefix='node_'), p.is_voting)
-            s += '---------- End of Manager peers (%s peers, %s good) ----------' % (len(self.peers), good)
+        peers = self.get_peers_copy()
+
+        good = reduce(lambda c, p: c + int(p.score >= 1000), peers, 0)
+        s = '---------- Start of Manager peers (%s peers, %s good) ----------\n' % (len(peers), good)
+        for p in peers:
+            voting_str = ' (voting)' if p.is_voting else ''
+            sw_ver = ''
+            cemented_count = ''
+            if p.telemetry:
+                sw_ver = ' v' + p.telemetry.get_sw_version()
+                cemented_count = ' cc=%s' % p.telemetry.cemented_count
+            s += '%41s:%5s (score:%4s)%s%s%s\n' % \
+                 ('[%s]' % p.ip, p.port, p.score, sw_ver, cemented_count, voting_str)
+            # if p.score >= 1000:
+            #    s += 'ID: %s, voting:%s\n' % (acctools.to_account_addr(p.peer_id, prefix='node_'), p.is_voting)
+        s += '---------- End of Manager peers (%s peers, %s good) ----------' % (len(peers), good)
+
         return s
 
 
@@ -341,53 +356,6 @@ class peer_crawler_thread(threading.Thread):
         print('Starting peer crawler in a thread')
         self.peerman.crawl(self.forever, self.delay)
         print('Peer crawler thread ended')
-
-
-class network_connections():
-    def __init__(self, peerman: peer_manager, inactivity_threshold_seconds=0, verbosity=0):
-        self.peerman = peerman
-        self.inactivity_threshold_seconds = inactivity_threshold_seconds
-        self.verbosity = verbosity
-
-        self.__connections: dict[Peer, peer_set] = {}
-
-    def register_connections(self, peer: Peer, new_peers: Iterable[Peer]):
-        for new_peer in new_peers:
-            if new_peer.ip.ipv6.is_unspecified:
-                continue
-
-            if new_peer not in self.__connections:
-                self.__connections[new_peer] = peer_set()
-
-            self.__connections[peer].add(new_peer)
-
-    def get_connections(self) -> dict[Peer, set[Peer]]:
-        return copy.deepcopy(self.__connections)
-
-    def run(self, initial_peer: Peer, interval_seconds=0):
-        self.__connections[initial_peer] = peer_set()
-
-        while True:
-            peers_list = [peer for peer in self.__connections]
-            for peer in peers_list:
-                new_peers = self.peerman.get_peers_from_peer(peer)
-                self.register_connections(peer, new_peers)
-                print(f"Received peers from {peer.ip}, active peer count for this peer is now {self.__connections[peer].__len__()}\nNow tracking {len(self.__connections)} peers in total")
-
-            if self.inactivity_threshold_seconds > 0:
-                for _, peers in self.__connections.items():
-                    peers.cleanup_inactive(self.inactivity_threshold_seconds)
-
-            time.sleep(interval_seconds)
-
-    def get_connections_flat(self) -> set[tuple[Peer, Peer]]:
-        connections = set()
-
-        for peer_origin, peers in self.__connections.items():
-            for peer_destination in peers:
-                connections.add((peer_origin, peer_destination))
-
-        return connections
 
 
 def spawn_peer_crawler_thread(ctx, forever, delay, verbosity):

--- a/peercrawler.py
+++ b/peercrawler.py
@@ -47,8 +47,9 @@ class peer_manager:
 
         self.__connections_graph: dict[Peer, peer_set] = {}
 
-        for peer in peers:
-            self.__connections_graph[peer] = peer_set()
+        if peers:
+            for peer in peers:
+                self.__connections_graph[peer] = peer_set()
 
         if listen:
             threading.Thread(target=self.listen_incoming, daemon=True).start()

--- a/peercrawler.py
+++ b/peercrawler.py
@@ -60,6 +60,9 @@ class peer_manager:
 
     def add_peers(self, from_peer: Peer, new_peers: Iterable[Peer]):
         with self.mutex:
+            if from_peer not in self.__connections_graph:
+                self.__connections_graph[from_peer] = peer_set()
+
             for new_peer in new_peers:
                 if new_peer.ip.ipv6.is_unspecified:
                     continue

--- a/peercrawler.py
+++ b/peercrawler.py
@@ -80,7 +80,7 @@ class peer_manager:
 
             time.sleep(inactivity_threshold_seconds)
 
-    def get_peers_copy(self) -> Collection[Peer]:
+    def get_peers_as_list(self) -> Collection[Peer]:
         with self.mutex:
             return self.__connections_graph.keys()
 
@@ -90,13 +90,13 @@ class peer_manager:
 
     def count_good_peers(self):
         counter = 0
-        for p in self.get_peers_copy():
+        for p in self.get_peers_as_list():
             if p.score >= 1000:
                 counter += 1
         return counter
 
     def count_peers(self):
-        return len(self.get_peers_copy())
+        return len(self.get_peers_as_list())
 
     def listen_incoming(self):
         with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
@@ -225,7 +225,7 @@ class peer_manager:
         logger.info("Starting a peer crawl")
 
         # it is important to take a copy of the peers so that it is not changing as we walk it
-        peers_copy = self.get_peers_copy()
+        peers_copy = self.get_peers_as_list()
         assert len(peers_copy) > 0
 
         def crawl_peer(peer: Peer):
@@ -257,7 +257,7 @@ class peer_manager:
             count += 1
 
     def __str__(self):
-        peers = self.get_peers_copy()
+        peers = self.get_peers_as_list()
 
         good = reduce(lambda c, p: c + int(p.score >= 1000), peers, 0)
         s = '---------- Start of Manager peers (%s peers, %s good) ----------\n' % (len(peers), good)
@@ -381,7 +381,7 @@ def run_peer_service_forever(peerman, addr='', port=7070):
                 conn.settimeout(10)
                 hdr = peer_service_header(peerman.ctx["net_id"], peerman.count_good_peers(), peerman.count_peers())
                 data = hdr.serialise()
-                json_list = jsonpickle.encode(peerman.get_peers_copy())
+                json_list = jsonpickle.encode(peerman.get_peers_as_list())
                 data += json_list.encode()
                 conn.sendall(data)
 

--- a/peercrawler.py
+++ b/peercrawler.py
@@ -49,7 +49,7 @@ class peer_manager:
 
         if peers:
             for peer in peers:
-                self.__connections_graph[peer] = peer_set()
+                self.add_peers(peer, [])
 
         if listen:
             threading.Thread(target=self.listen_incoming, daemon=True).start()
@@ -240,9 +240,8 @@ class peer_manager:
 
     def crawl(self, forever, delay, max_workers=4):
         initial_peers = get_all_dns_addresses_as_peers(self.ctx['peeraddr'], self.ctx['peerport'], -1)
-        with self.mutex:
-            for peer in initial_peers:
-                self.__connections_graph[peer] = peer_set()
+        for peer in initial_peers:
+            self.add_peers(peer, [])
 
         self.crawl_once(max_workers)
         logger.info(self)

--- a/peercrawler_html_server.py
+++ b/peercrawler_html_server.py
@@ -36,7 +36,7 @@ def bg_thread_func():
 def main_website():
     global app, peerman, representatives
 
-    peers_copy = list(peerman.get_peers_copy())
+    peers_copy = list(peerman.get_peers_as_list())
 
     peer_list = []
     for peer in peers_copy:
@@ -85,7 +85,7 @@ def main_website():
 def json():
     global app, peerman
 
-    peers = peerman.get_peers_copy()
+    peers = peerman.get_peers_as_list()
     js = jsonencoder.to_json(list(peers))
     return Response(js, status=200, mimetype="application/json")
 

--- a/peercrawler_rest_server.py
+++ b/peercrawler_rest_server.py
@@ -17,7 +17,7 @@ peerman = peercrawler.peer_manager(ctx, verbosity=1)
 def main_route():
     global app, peerman
 
-    peers = peerman.get_peers_copy()
+    peers = peerman.get_peers_as_list()
     js = jsonencoder.to_json(list(peers))
     return flask.Response(js, status=200, mimetype='application/json')
 


### PR DESCRIPTION
I ended up just replacing the peer_set collection in peer_manager with a graph of the peers connections instead, since they hold the exact same information but in a different structure.
This removes the need for network_connections, which had a lot of duplicate logic with the peer_manager.