### PR TITLE
Include a list of the id of connected peers in the peercrawler json view

### DIFF
--- a/peercrawler.py
+++ b/peercrawler.py
@@ -494,7 +494,7 @@ def get_peers_from_service(ctx: dict, url = None):
     session = requests.Session()
     resp = session.get(url, timeout=5)
     json_resp = resp.json()
-    return [ Peer.from_json(r) for r in json_resp ]
+    return [Peer.from_json(r) for r in json_resp.values()]
 
 
 def get_initial_connected_socket(ctx, peers=None):

--- a/representatives.py
+++ b/representatives.py
@@ -135,7 +135,7 @@ def rpc_representatives(session: requests.Session) -> dict:
     return result
 
 
-def get_representatives() -> Dict[str, Representative]:
+def get_representatives(peer_service_url: str = None) -> Dict[str, Representative]:
     session = requests.Session()
 
     quorum_reply = rpc_confirmation_quorum(session)
@@ -190,7 +190,7 @@ def get_representatives() -> Dict[str, Representative]:
                 rep.protover = peers[endpoint]['protocol_version']
 
     # merge in voting capabilities from peercrawler
-    peers = peercrawler.get_peers_from_service(pynanocoin.livectx)
+    peers = peercrawler.get_peers_from_service(pynanocoin.livectx, url=peer_service_url)
     for peer in peers:
         if peer.peer_id:
             for acc, rep in reps.items():

--- a/web_server.py
+++ b/web_server.py
@@ -98,10 +98,10 @@ def main_website():
 
 @app.route("/peercrawler/json")
 def json():
-    peers = peerman.get_peers_as_list()
-    js = jsonencoder.to_json(list(peers))
+    serialized_connections = peerman.serialize_dict()
+    _json = jsonencoder.to_json(serialized_connections)
 
-    return Response(js, status=200, mimetype="application/json")
+    return Response(_json, status=200, mimetype="application/json")
 
 
 @app.route("/peercrawler/logs")

--- a/web_server.py
+++ b/web_server.py
@@ -196,8 +196,9 @@ def render_graph_thread(interval_seconds: int):
 
 
 def generate_representatives_thread(interval_seconds: int):
+    peer_service_url = f"http://127.0.0.1:{app.config['args'].http_port}/peercrawler/json"
     while True:
-        _representatives = get_representatives()
+        _representatives = get_representatives(peer_service_url)
         json_representatives = jsonencoder.to_json(_representatives)
         cache.set("representatives", json_representatives)
 


### PR DESCRIPTION
In order to show the list of connected peers in the detailed peer info page, the list of connected peers needs to be included in the peercrawler json view.
I ended up changing the data served by the /peercrawler/json endpoint to the result of the `serialize` method of peer_manager, which creates a json structure of the connections, where the keys are the `id()` of the peer object and each peer object include an additional property called `connections`, with an array of the keys of the connected peers.
I'm including an example of the new response of the endpoint in the attached file. Let me know what you think of this approach.

[peers.txt](https://github.com/dsiganos/xnolib/files/8970225/peers.txt)